### PR TITLE
Hotfix: remove maxSize limit in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -151,7 +151,6 @@ export default defineConfig({
                             priority: 50,
                         },
                     ],
-                    maxSize: 100 * 1024,
                 },
             },
         },


### PR DESCRIPTION
(hopefully) fixes "class extends value undefined is not a constructor or null"

Edit: actually fixed lol :) 