### PR TITLE
Refactor game systems to use service layer

### DIFF
--- a/src/gameScene/services/GameSceneAnimationService.js
+++ b/src/gameScene/services/GameSceneAnimationService.js
@@ -1,0 +1,29 @@
+import { updateCamera as runUpdateCamera } from "../sceneUpdate/camera";
+import { updateClickToCut as runUpdateClickToCut } from "../sceneUpdate/clickToCut";
+
+/** @typedef {import("../update").default} GameSceneUpdate */
+
+class GameSceneAnimationService {
+    /**
+     * @param {GameSceneUpdate} scene
+     */
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    /**
+     * @param {number} delta
+     */
+    updateCamera(delta) {
+        runUpdateCamera.call(this.scene, delta);
+    }
+
+    /**
+     * @param {number} delta
+     */
+    updateClickToCut(delta) {
+        runUpdateClickToCut.call(this.scene, delta);
+    }
+}
+
+export default GameSceneAnimationService;

--- a/src/gameScene/services/GameSceneCandyService.js
+++ b/src/gameScene/services/GameSceneCandyService.js
@@ -1,0 +1,65 @@
+import { updateBungees as runUpdateBungees } from "../sceneUpdate/bungees";
+import { updateCollectibles as runUpdateCollectibles } from "../sceneUpdate/collectibles";
+import { updateHazards as runUpdateHazards } from "../sceneUpdate/hazards";
+import { updateTargetState as runUpdateTargetState } from "../sceneUpdate/targetState";
+import { updateSpecial as runUpdateSpecial } from "../sceneUpdate/special";
+import * as GameSceneConstants from "../constants";
+
+/** @typedef {import("../update").default} GameSceneUpdate */
+
+class GameSceneCandyService {
+    /**
+     * @param {GameSceneUpdate} scene
+     */
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    /**
+     * @param {number} delta
+     * @returns {number}
+     */
+    updateBungees(delta) {
+        return runUpdateBungees.call(this.scene, delta);
+    }
+
+    /**
+     * @param {number} delta
+     */
+    updateCollectibles(delta) {
+        runUpdateCollectibles.call(this.scene, delta);
+    }
+
+    /**
+     * @param {number} delta
+     * @param {number} numGrabs
+     * @returns {boolean}
+     */
+    updateHazards(delta, numGrabs) {
+        return runUpdateHazards.call(this.scene, delta, numGrabs);
+    }
+
+    /**
+     * @param {number} delta
+     * @returns {import("./types").TargetUpdateResult}
+     */
+    updateTargetState(delta) {
+        const shouldContinue = runUpdateTargetState.call(this.scene, delta);
+        if (shouldContinue) {
+            return { continue: true };
+        }
+
+        const won =
+            this.scene.target.currentTimelineIndex === GameSceneConstants.CharAnimation.WIN;
+        return { continue: false, reason: won ? "game_won" : "game_lost" };
+    }
+
+    /**
+     * @param {number} delta
+     */
+    updateSpecial(delta) {
+        runUpdateSpecial.call(this.scene, delta);
+    }
+}
+
+export default GameSceneCandyService;

--- a/src/gameScene/services/GameScenePhysicsService.js
+++ b/src/gameScene/services/GameScenePhysicsService.js
@@ -1,0 +1,21 @@
+import { updateBasics as runUpdateBasics } from "../sceneUpdate/basics";
+
+/** @typedef {import("../update").default} GameSceneUpdate */
+
+class GameScenePhysicsService {
+    /**
+     * @param {GameSceneUpdate} scene
+     */
+    constructor(scene) {
+        this.scene = scene;
+    }
+
+    /**
+     * @param {number} delta
+     */
+    updateBasics(delta) {
+        runUpdateBasics.call(this.scene, delta);
+    }
+}
+
+export default GameScenePhysicsService;

--- a/src/gameScene/services/types.js
+++ b/src/gameScene/services/types.js
@@ -1,0 +1,29 @@
+/**
+ * Provides physics operations used by the game loop.
+ * @typedef {object} PhysicsService
+ * @property {(delta: number) => void} updateBasics
+ */
+
+/**
+ * Describes the outcome of updating the candy target state.
+ * @typedef {object} TargetUpdateResult
+ * @property {boolean} continue
+ * @property {"game_won" | "game_lost"} [reason]
+ */
+
+/**
+ * Provides candy-related state management utilities.
+ * @typedef {object} CandyService
+ * @property {(delta: number) => number} updateBungees
+ * @property {(delta: number) => void} updateCollectibles
+ * @property {(delta: number, numGrabs: number) => boolean} updateHazards
+ * @property {(delta: number) => TargetUpdateResult} updateTargetState
+ * @property {(delta: number) => void} updateSpecial
+ */
+
+/**
+ * Provides animation helpers used by the game systems.
+ * @typedef {object} AnimationService
+ * @property {(delta: number) => void} updateCamera
+ * @property {(delta: number) => void} updateClickToCut
+ */

--- a/src/gameScene/systems/BungeeSystem.js
+++ b/src/gameScene/systems/BungeeSystem.js
@@ -1,16 +1,15 @@
-import { updateBungees as runUpdateBungees } from "../sceneUpdate/bungees";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").BungeeSystemDependencies} BungeeSystemDependencies */
+/** @typedef {import("../services/types").CandyService} CandyService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {CandyService} service
      * @param {number} delta
      */
-    updateBungees(scene, delta) {
-        return runUpdateBungees.call(scene, delta);
+    updateBungees(service, delta) {
+        return service.updateBungees(delta);
     },
 });
 
@@ -34,7 +33,7 @@ class BungeeSystem {
      * @returns {import("./types").SystemResult}
      */
     update(delta, sharedState) {
-        const numGrabs = this.dependencies.updateBungees(this.context.scene, delta);
+        const numGrabs = this.dependencies.updateBungees(this.context.candy, delta);
         sharedState.numGrabs = numGrabs;
         return { continue: true };
     }

--- a/src/gameScene/systems/CameraSystem.js
+++ b/src/gameScene/systems/CameraSystem.js
@@ -1,16 +1,15 @@
-import { updateCamera as runUpdateCamera } from "../sceneUpdate/camera";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").CameraSystemDependencies} CameraSystemDependencies */
+/** @typedef {import("../services/types").AnimationService} AnimationService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {AnimationService} service
      * @param {number} delta
      */
-    updateCamera(scene, delta) {
-        runUpdateCamera.call(scene, delta);
+    updateCamera(service, delta) {
+        service.updateCamera(delta);
     },
 });
 
@@ -31,7 +30,7 @@ class CameraSystem {
      * @returns {import("./types").SystemResult}
      */
     update(delta, _sharedState) {
-        this.dependencies.updateCamera(this.context.scene, delta);
+        this.dependencies.updateCamera(this.context.animation, delta);
         return { continue: true };
     }
 }

--- a/src/gameScene/systems/CollectibleSystem.js
+++ b/src/gameScene/systems/CollectibleSystem.js
@@ -1,16 +1,15 @@
-import { updateCollectibles as runUpdateCollectibles } from "../sceneUpdate/collectibles";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").CollectibleSystemDependencies} CollectibleSystemDependencies */
+/** @typedef {import("../services/types").CandyService} CandyService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {CandyService} service
      * @param {number} delta
      */
-    updateCollectibles(scene, delta) {
-        return runUpdateCollectibles.call(scene, delta);
+    updateCollectibles(service, delta) {
+        service.updateCollectibles(delta);
     },
 });
 
@@ -35,7 +34,7 @@ class CollectibleSystem {
      */
     update(delta, _sharedState) {
         // CollectibleSystem always continues (returns true)
-        this.dependencies.updateCollectibles(this.context.scene, delta);
+        this.dependencies.updateCollectibles(this.context.candy, delta);
         return { continue: true };
     }
 }

--- a/src/gameScene/systems/HazardSystem.js
+++ b/src/gameScene/systems/HazardSystem.js
@@ -1,17 +1,16 @@
-import { updateHazards as runUpdateHazards } from "../sceneUpdate/hazards";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").HazardSystemDependencies} HazardSystemDependencies */
+/** @typedef {import("../services/types").CandyService} CandyService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {CandyService} service
      * @param {number} delta
      * @param {number} numGrabs
      */
-    updateHazards(scene, delta, numGrabs) {
-        return runUpdateHazards.call(scene, delta, numGrabs);
+    updateHazards(service, delta, numGrabs) {
+        return service.updateHazards(delta, numGrabs);
     },
 });
 
@@ -36,7 +35,11 @@ class HazardSystem {
      */
     update(delta, sharedState) {
         const numGrabs = sharedState.numGrabs ?? 0;
-        const shouldContinue = this.dependencies.updateHazards(this.context.scene, delta, numGrabs);
+        const shouldContinue = this.dependencies.updateHazards(
+            this.context.candy,
+            delta,
+            numGrabs
+        );
 
         // updateHazards returns false when candy hits spike (game lost)
         return shouldContinue ? { continue: true } : { continue: false, reason: "game_lost" };

--- a/src/gameScene/systems/InteractionSystem.js
+++ b/src/gameScene/systems/InteractionSystem.js
@@ -1,16 +1,15 @@
-import { updateClickToCut as runUpdateClickToCut } from "../sceneUpdate/clickToCut";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").InteractionSystemDependencies} InteractionSystemDependencies */
+/** @typedef {import("../services/types").AnimationService} AnimationService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {AnimationService} service
      * @param {number} delta
      */
-    updateClickToCut(scene, delta) {
-        runUpdateClickToCut.call(scene, delta);
+    updateClickToCut(service, delta) {
+        service.updateClickToCut(delta);
     },
 });
 
@@ -34,7 +33,7 @@ class InteractionSystem {
      * @returns {import("./types").SystemResult}
      */
     update(delta, _sharedState) {
-        this.dependencies.updateClickToCut(this.context.scene, delta);
+        this.dependencies.updateClickToCut(this.context.animation, delta);
         return { continue: true };
     }
 }

--- a/src/gameScene/systems/PhysicsSystem.js
+++ b/src/gameScene/systems/PhysicsSystem.js
@@ -1,16 +1,15 @@
-import { updateBasics as runUpdateBasics } from "../sceneUpdate/basics";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").PhysicsSystemDependencies} PhysicsSystemDependencies */
+/** @typedef {import("../services/types").PhysicsService} PhysicsService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {PhysicsService} service
      * @param {number} delta
      */
-    updateBasics(scene, delta) {
-        runUpdateBasics.call(scene, delta);
+    updateBasics(service, delta) {
+        service.updateBasics(delta);
     },
 });
 
@@ -31,7 +30,7 @@ class PhysicsSystem {
      * @returns {import("./types").SystemResult}
      */
     update(delta, _sharedState) {
-        this.dependencies.updateBasics(this.context.scene, delta);
+        this.dependencies.updateBasics(this.context.physics, delta);
         return { continue: true };
     }
 }

--- a/src/gameScene/systems/SpecialSystem.js
+++ b/src/gameScene/systems/SpecialSystem.js
@@ -1,16 +1,15 @@
-import { updateSpecial as runUpdateSpecial } from "../sceneUpdate/special";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").SpecialSystemDependencies} SpecialSystemDependencies */
+/** @typedef {import("../services/types").CandyService} CandyService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {CandyService} service
      * @param {number} delta
      */
-    updateSpecial(scene, delta) {
-        return runUpdateSpecial.call(scene, delta);
+    updateSpecial(service, delta) {
+        service.updateSpecial(delta);
     },
 });
 
@@ -32,7 +31,7 @@ class SpecialSystem {
      */
     update(delta, _sharedState) {
         // SpecialSystem always continues (always returns true)
-        this.dependencies.updateSpecial(this.context.scene, delta);
+        this.dependencies.updateSpecial(this.context.candy, delta);
         return { continue: true };
     }
 }

--- a/src/gameScene/systems/TargetSystem.js
+++ b/src/gameScene/systems/TargetSystem.js
@@ -1,17 +1,17 @@
-import { updateTargetState as runUpdateTargetState } from "../sceneUpdate/targetState";
-import * as GameSceneConstants from "../constants";
-
 /** @typedef {import("./types").GameSystemContext} GameSystemContext */
 /** @typedef {import("./types").GameSystemSharedState} GameSystemSharedState */
 /** @typedef {import("./types").TargetSystemDependencies} TargetSystemDependencies */
+/** @typedef {import("../services/types").TargetUpdateResult} TargetUpdateResult */
+/** @typedef {import("../services/types").CandyService} CandyService */
 
 const defaultDependencies = Object.freeze({
     /**
-     * @param {import("../update").default} scene
+     * @param {CandyService} service
      * @param {number} delta
+     * @returns {TargetUpdateResult}
      */
-    updateTargetState(scene, delta) {
-        return runUpdateTargetState.call(scene, delta);
+    updateTargetState(service, delta) {
+        return service.updateTargetState(delta);
     },
 });
 
@@ -35,16 +35,10 @@ class TargetSystem {
      * @returns {import("./types").SystemResult}
      */
     update(delta, _sharedState) {
-        const shouldContinue = this.dependencies.updateTargetState(this.context.scene, delta);
+        const result = this.dependencies.updateTargetState(this.context.candy, delta);
 
-        if (!shouldContinue) {
-            // updateTargetState returns false when:
-            // 1. Candy reaches target (line 46: gameWon called, returns false)
-            // 2. Candy goes off screen (lines 88-89: gameLost called, returns false)
-            // gameWon() sets target animation to WIN, gameLost() doesn't
-            const scene = this.context.scene;
-            const won = scene.target.currentTimelineIndex === GameSceneConstants.CharAnimation.WIN;
-            return { continue: false, reason: won ? "game_won" : "game_lost" };
+        if (!result.continue) {
+            return { continue: false, reason: result.reason };
         }
 
         return { continue: true };

--- a/src/gameScene/systems/types.js
+++ b/src/gameScene/systems/types.js
@@ -1,10 +1,13 @@
-/**
- * @typedef {import("../update").default} GameSceneUpdate
- */
+/** @typedef {import("../services/types").PhysicsService} PhysicsService */
+/** @typedef {import("../services/types").CandyService} CandyService */
+/** @typedef {import("../services/types").AnimationService} AnimationService */
+/** @typedef {import("../services/types").TargetUpdateResult} TargetUpdateResult */
 
 /**
  * @typedef {object} GameSystemContext
- * @property {GameSceneUpdate} scene
+ * @property {PhysicsService} physics
+ * @property {CandyService} candy
+ * @property {AnimationService} animation
  * @property {import("../plugins/GameObjectPluginManager").default} pluginManager
  */
 
@@ -41,57 +44,41 @@
  */
 
 /**
- * @typedef {(scene: GameSceneUpdate, delta: number) => void} SceneVoidUpdate
- */
-
-/**
- * @typedef {(scene: GameSceneUpdate, delta: number) => number} SceneNumberUpdate
- */
-
-/**
- * @typedef {(scene: GameSceneUpdate, delta: number) => boolean} SceneBooleanUpdate
- */
-
-/**
- * @typedef {(scene: GameSceneUpdate, delta: number, numGrabs: number) => boolean} SceneHazardUpdate
- */
-
-/**
  * @typedef {object} PhysicsSystemDependencies
- * @property {SceneVoidUpdate} updateBasics
+ * @property {(service: PhysicsService, delta: number) => void} updateBasics
  */
 
 /**
  * @typedef {object} CameraSystemDependencies
- * @property {SceneVoidUpdate} updateCamera
+ * @property {(service: AnimationService, delta: number) => void} updateCamera
  */
 
 /**
  * @typedef {object} BungeeSystemDependencies
- * @property {SceneNumberUpdate} updateBungees
+ * @property {(service: CandyService, delta: number) => number} updateBungees
  */
 
 /**
  * @typedef {object} CollectibleSystemDependencies
- * @property {SceneBooleanUpdate} updateCollectibles
+ * @property {(service: CandyService, delta: number) => void} updateCollectibles
  */
 
 /**
  * @typedef {object} HazardSystemDependencies
- * @property {SceneHazardUpdate} updateHazards
+ * @property {(service: CandyService, delta: number, numGrabs: number) => boolean} updateHazards
  */
 
 /**
  * @typedef {object} TargetSystemDependencies
- * @property {SceneBooleanUpdate} updateTargetState
+ * @property {(service: CandyService, delta: number) => TargetUpdateResult} updateTargetState
  */
 
 /**
  * @typedef {object} SpecialSystemDependencies
- * @property {SceneBooleanUpdate} updateSpecial
+ * @property {(service: CandyService, delta: number) => void} updateSpecial
  */
 
 /**
  * @typedef {object} InteractionSystemDependencies
- * @property {SceneVoidUpdate} updateClickToCut
+ * @property {(service: AnimationService, delta: number) => void} updateClickToCut
  */

--- a/src/gameScene/update.js
+++ b/src/gameScene/update.js
@@ -11,6 +11,9 @@ import GameSceneSelectionDelegate from "./sceneUpdate/selection";
 import GameObjectPluginManager from "./plugins/GameObjectPluginManager";
 import { createCoreSystems } from "./systems";
 import GameSceneCharacter from "./character";
+import GameScenePhysicsService from "./services/GameScenePhysicsService";
+import GameSceneCandyService from "./services/GameSceneCandyService";
+import GameSceneAnimationService from "./services/GameSceneAnimationService";
 
 /**
  * @template {Record<string, (...args: any[]) => any>} T
@@ -93,9 +96,15 @@ class GameSceneUpdate extends GameSceneCharacter {
 
         const { plugins = [], systems } = options;
 
+        this.physicsService = new GameScenePhysicsService(this);
+        this.candyService = new GameSceneCandyService(this);
+        this.animationService = new GameSceneAnimationService(this);
+
         /** @type {GameSystemContext} */
         const systemContext = {
-            scene: this,
+            physics: this.physicsService,
+            candy: this.candyService,
+            animation: this.animationService,
             // Placeholder, assigned after plugin manager instantiation
             pluginManager: /** @type {any} */ (null),
         };


### PR DESCRIPTION
## Description

- Added physics, candy, and animation service interfaces along with scene-backed implementations so systems can call scoped behaviors instead of the monolithic update class.

- Updated `GameSceneUpdate` to instantiate the new services and supply them through the shared system context used by plugins and systems.

- Reworked system context typings and system implementations to depend on the specific services, letting the candy service report win/loss outcomes while other systems call their respective service scopes.